### PR TITLE
Updated index.html with legal notice

### DIFF
--- a/Schedule-maker/html/index.html
+++ b/Schedule-maker/html/index.html
@@ -49,6 +49,7 @@ Free for personal and commercial use under the CCA 3.0 license (html5up.net/lice
                             Finally, click the bookmarklet that you saved at first. You'll be prompted in a few seconds to save the iCalendar file and voilá, you now have your Class Schedule in an Electronic Calendar form!
                         </li>
                     </ul>
+                    <h2
                 </section>
 
             </div>
@@ -58,6 +59,7 @@ Free for personal and commercial use under the CCA 3.0 license (html5up.net/lice
                 <section style="text-align: center">
                     <a href="https://github.com/SidPagariya" class="button">@SidPagariya</a>
                 </section>
+                <p class="copyright">UMich ScheduleMaker is an open-source software released under the MIT License. <br></br> The authors and copyright holder are not liable for you missing class due to an error in the exporter.</p> 
                 <p class="copyright">&copy; 2018 UMich ScheduleMaker. Design: <a href="https://html5up.net">HTML5 UP</a>.</p>
             </footer>
         </div>

--- a/Schedule-maker/html/index.html
+++ b/Schedule-maker/html/index.html
@@ -49,7 +49,6 @@ Free for personal and commercial use under the CCA 3.0 license (html5up.net/lice
                             Finally, click the bookmarklet that you saved at first. You'll be prompted in a few seconds to save the iCalendar file and voilá, you now have your Class Schedule in an Electronic Calendar form!
                         </li>
                     </ul>
-                    <h2
                 </section>
 
             </div>
@@ -59,7 +58,7 @@ Free for personal and commercial use under the CCA 3.0 license (html5up.net/lice
                 <section style="text-align: center">
                     <a href="https://github.com/SidPagariya" class="button">@SidPagariya</a>
                 </section>
-                <p class="copyright">UMich ScheduleMaker is an open-source software released under the MIT License. <br></br> The authors and copyright holder are not liable for you missing class due to an error in the exporter.</p> 
+                <p class="copyright">UMich ScheduleMaker is an open-source software released under the MIT License.<br>The authors and copyright holder are not liable for you missing class due to an error in the exporter.</p>
                 <p class="copyright">&copy; 2018 UMich ScheduleMaker. Design: <a href="https://html5up.net">HTML5 UP</a>.</p>
             </footer>
         </div>


### PR DESCRIPTION
Legalese addition:

- "UMich ScheduleMaker is an open-source software released under the MIT License. The authors and copyright holder are not liable for you missing class due to an error in the exporter."
