### PR TITLE
Feature/detect-term

### DIFF
--- a/LSA-CG-scrape/find_sections.py
+++ b/LSA-CG-scrape/find_sections.py
@@ -1,5 +1,6 @@
 import urllib3
 from bs4 import BeautifulSoup
+import re # importing regex functionality
 
 def soupObj(url):
     http = urllib3.PoolManager()
@@ -7,11 +8,31 @@ def soupObj(url):
     soup = BeautifulSoup(response.data, 'html.parser')
     return soup
 
-def pre_url(dept, cat):
+# Function to retrieve the 'termArray' query for the current semester
+# Thereby future-proofing the script :)
+# The previous version was 'stuck' on Fall 2018
+def get_term():
+    soup = soupObj('http://www.lsa.umich.edu/cg/default.aspx')
+    # The LSA CG webpage has a navbar with a button to browse all UG subjects being offered in the current term
+    # One of the queries in the href attribute of this button contains the current term ID
+    # The line below obtains a string of this format: 
+    #   cg_subjectlist.aspx?termArray=f_19_2260&cgtype=ug&allsections=true
+    link = soup.find('a', attrs={'id': 'hyperlinkBrowseUGSubjectList'})['href']
+    # Using a regular expression to match the value for 'termArray'
+    matches = re.findall(r'[\?&]termArray=([^&$\s]*)', link)
+    term = matches[0]
+    # Return the term ID, for example, 'f_19_2260'
+    return term
+
+# Added an argument for the term ID
+def pre_url(dept, cat, term):
     mast_url = "http://www.lsa.umich.edu/cg/"
-    url_pre = "cg_results.aspx?termArray=f_18_2210&cgtype=ug&show=100&department="
+    url_pre = "cg_results.aspx"
+    # Split the URL into more parts so the term ID can be appended
+    url_query_term = "?termArray=" + term
+    url_query_others = "&cgtype=ug&show=100&department="
     url_post = "&catalog="
-    url = mast_url+url_pre+dept+url_post+cat
+    url = mast_url+url_pre+url_query_term+url_query_others+dept+url_post+cat # URL construction modified to suit above changes
     soup = soupObj(url)
     if soup.find('div', attrs={'id':'contentMain_panelError'}) == None:
         classlinks = soup.find('div', attrs={'class':'row ClassRow ClassHyperlink result'})
@@ -30,6 +51,6 @@ def list_sec(pre_url):
     return dict
 
 def find_sections(dept, cat):
-    return list_sec(pre_url(dept, cat))
+    return list_sec(pre_url(dept, cat, get_term())) # Get term ID and pass it to pre_url()
     
 print(find_sections('EECS', '280'))

--- a/LSA-CG-scrape/scrape.py
+++ b/LSA-CG-scrape/scrape.py
@@ -1,5 +1,6 @@
 import urllib3
 from bs4 import BeautifulSoup
+import re # importing regex functionality
 
 def soupObj(url):
     http = urllib3.PoolManager()
@@ -7,11 +8,31 @@ def soupObj(url):
     soup = BeautifulSoup(response.data, 'html.parser')
     return soup
 
-def pre_url(dept, cat):
+# Function to retrieve the 'termArray' query for the current semester
+# Thereby future-proofing the script :)
+# The previous version was 'stuck' on Fall 2018
+def get_term():
+    soup = soupObj('http://www.lsa.umich.edu/cg/default.aspx')
+    # The LSA CG webpage has a navbar with a button to browse all UG subjects being offered in the current term
+    # One of the queries in the href attribute of this button contains the current term ID
+    # The line below obtains a string of this format: 
+    #   cg_subjectlist.aspx?termArray=f_19_2260&cgtype=ug&allsections=true
+    link = soup.find('a', attrs={'id': 'hyperlinkBrowseUGSubjectList'})['href']
+    # Using a regular expression to match the value for 'termArray'
+    matches = re.findall(r'[\?&]termArray=([^&$\s]*)', link)
+    term = matches[0]
+    # Return the term ID, for example, 'f_19_2260'
+    return term
+
+# Added an argument for the term ID
+def pre_url(dept, cat, term):
     mast_url = "http://www.lsa.umich.edu/cg/"
-    url_pre = "cg_results.aspx?termArray=f_18_2210&cgtype=ug&show=100&department="
+    url_pre = "cg_results.aspx"
+    # Split the URL into more parts so the term ID can be appended
+    url_query_term = "?termArray=" + term
+    url_query_others = "&cgtype=ug&show=100&department="
     url_post = "&catalog="
-    url = mast_url+url_pre+dept+url_post+cat
+    url = mast_url+url_pre+url_query_term+url_query_others+dept+url_post+cat # URL construction modified to suit above changes
     soup = soupObj(url)
     if soup.find('div', attrs={'id':'contentMain_panelError'}) == None:
         classlinks = soup.find('div', attrs={'class':'row ClassRow ClassHyperlink result'})
@@ -35,8 +56,9 @@ def list_sec(pre_url):
     return dict
 
 def find_sections(dept, cat):
-    return list_sec(pre_url(dept, cat))
+    return list_sec(pre_url(dept, cat, get_term())) # Get term ID and pass it to pre_url()
 
+get_term()  
 print(find_sections('EECSS', '280'))
 
 #dept = 'MATH'


### PR DESCRIPTION
I noticed that the script currently scrapes the CG for Fall 2018 without a check for the most recent/current term. This should solve that issue by adding a function to modify the URL to point to the current term.

Upon inspection of the CG, I found that each term is given an ID-like string. This "ID" is passed as a query when retrieving a certain webpage in the CG.

- Fall 2018's ID is `f_18_2210`
- Fall 2019's ID is `f_19_2260`

So,
- A sample URL for the Fall 2018 CG is `https://www.lsa.umich.edu/cg/cg_subjectlist.aspx?termArray=`**`f_18_2210`**`&cgtype=ug&allsections=true`
- A sample URL for the Fall 2019 CG is `https://www.lsa.umich.edu/cg/cg_subjectlist.aspx?termArray=`**`f_19_2260`**`&cgtype=ug&allsections=true`

I'm not sure about *how* exactly this ID is computed else I would have taken that route. Instead, I found that some buttons on the main CG page have attributes that contain this ID.

I used bs4 to parse the main CG page and find the element containing the term ID. Then, using some regex matching, the term ID is retrieved and passed to the function that constructs the URL to be parsed. 

I modified the URL-constructing function to accommodate for this change.

All-in-all, this should future-proof your script. :)